### PR TITLE
move GKE quickstart first, namespace consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Redis Labs helm repository
 
+## GKE quickstart
+
+```bash
+password=$(gcloud container clusters describe YOUR_SETUP_NAME --zone us-central1-a | grep password | cut -d":" -f 2 | tr -d " ")
+kubectl --username=admin --password=$password apply -f rbac_tiller.yaml
+helm init --service-account tiller
+helm install --namespace redis -n 'redis-enterprise' ./redis-enterprise
+```
+
 ## Redis Enterprise Chart
 
  To install the chart just run: 
@@ -9,15 +18,6 @@ helm install --namespace redis -n 'redis-enterprise' ./redis-enterprise
 To install the chart with an override file:
  ```bash
 helm install --namespace redis -n 'redis-enterprise' ./redis-enterprise -f ./redis-enterprise/values.yaml -f ./override-values.yaml
-```
-
-### GKE quickstart
-
-```bash
-password=$(gcloud container clusters describe YOUR_SETUP_NAME --zone us-central1-a | grep password | cut -d":" -f 2 | tr -d " ")
-kubectl --username=admin --password=$password apply -f rbac_tiller.yaml
-helm init --service-account tiller
-helm install --namespace redis -n 'prod' ./redis-enterprise
 ```
 
 ### Generate static files

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Redis Labs helm repository
 
-## GKE quickstart
+## Helm initialization on GKE
 
 ```bash
-password=$(gcloud container clusters describe YOUR_SETUP_NAME --zone us-central1-a | grep password | cut -d":" -f 2 | tr -d " ")
+password=$(gcloud container clusters describe YOUR_SETUP_NAME --zone YOUR_ZONE | grep password | cut -d":" -f 2 | tr -d " ")
 kubectl --username=admin --password=$password apply -f rbac_tiller.yaml
 helm init --service-account tiller
 helm install --namespace redis -n 'redis-enterprise' ./redis-enterprise


### PR DESCRIPTION
Multiple testers have failed to use the GKE Quickstart because the preceding "Redis Enterprise Chart" section will not work for a first time user.  Secondly, the namespace argument is not consistent in the examples.